### PR TITLE
Add light theme button styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,12 @@ button{
   background:#1f2a44;color:var(--text);border:none;border-radius:12px;
   padding:12px 16px;min-height:44px;cursor:pointer;transition:.15s;box-shadow:var(--shadow)
 }
+[data-theme="light"] button{
+  background:var(--ghost);
+  color:var(--text);
+  border:1px solid var(--ghost-border);
+  box-shadow:var(--shadow-1);
+}
 button:hover{transform:translateY(-1px);filter:brightness(1.1)}
 .btn-accent{background:linear-gradient(135deg,#34d399,#22c55e);color:#fff}
 [data-theme="light"] .btn-accent{background:linear-gradient(180deg,var(--accent) 0%,var(--accent-600) 100%);border:1px solid rgba(0,0,0,.04)}


### PR DESCRIPTION
## Summary
- adjust base button style for light theme with ghost background, border, and shadow

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 - <<'PY' ...` (contrast ratio check)


------
https://chatgpt.com/codex/tasks/task_e_689dcdd46634832f9f82c5dac4bd57fd