### PR TITLE
Lock fields until authentication

### DIFF
--- a/app.js
+++ b/app.js
@@ -791,6 +791,14 @@
   // ---------- auth state / realtime sync ----------
   let unsubscribeGroup = null;
 
+  function setFieldsLocked(lock){
+    $$("input, button, select, textarea").forEach(el => {
+      if (el.id === 'loginBtn') return;
+      if (el.closest('#authModal')) return;
+      el.disabled = lock;
+    });
+  }
+
   function clearUIOnSignOut(){
     // Clear in-memory + local cache (do NOT touch Firestore)
     state = { people: [], expenses: [] };
@@ -819,12 +827,14 @@
 
         if (loginBtn)  loginBtn.style.display  = 'none';
         if (logoutBtn) logoutBtn.style.display = 'inline-block';
+        setFieldsLocked(false);
       } else {
         if (unsubscribeGroup) unsubscribeGroup();
         unsubscribeGroup = null;
         if (loginBtn)  loginBtn.style.display  = 'inline-block';
         if (logoutBtn) logoutBtn.style.display = 'none';
         clearUIOnSignOut();
+        setFieldsLocked(true);
       }
     });
   }
@@ -837,6 +847,7 @@
     if (!ok) console.warn('Firebase SDK not ready in time');
 
     renderPeople(); renderExpenses(); computeBalances(); updateSplitUI();
+    setFieldsLocked(true);
     applyTheme(localStorage.getItem('spl-theme')||'dark');
     if ($('#saveStatus')) markSaved();
 


### PR DESCRIPTION
## Summary
- Disable all inputs, selects, and buttons until a user signs in
- Unlock controls on auth success and relock them on sign-out
- Ensure initial page load locks controls before authentication state resolves

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd5f2d7e4832f9c7295e9d9b9604f