### PR TITLE
Blur page when fields are locked

### DIFF
--- a/app.js
+++ b/app.js
@@ -792,6 +792,7 @@
   let unsubscribeGroup = null;
 
   function setFieldsLocked(lock){
+    document.body.classList.toggle('locked', lock);
     $$("input, button, select, textarea").forEach(el => {
       if (el.id === 'loginBtn') return;
       if (el.closest('#authModal')) return;

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,8 @@ h1{font-size:28px}
 h2{font-size:20px;color:var(--muted);font-weight:600}
 
 .wrap{max-width:1400px;margin:28px auto;padding:0 16px}
+body.locked .wrap{filter:blur(4px);pointer-events:none}
+body.locked #authModal{filter:none;pointer-events:auto}
 .grid{display:grid;gap:16px;grid-template-columns:1.4fr .8fr}
 @media (max-width:1200px){.wrap{max-width:98vw}.grid{grid-template-columns:1fr}}
 


### PR DESCRIPTION
## Summary
- Add `.locked` CSS class to blur and disable the main wrapper while leaving auth modal interactive
- Toggle `.locked` on the document body in `setFieldsLocked` to reflect auth state

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd996cc70832fbd03862ec57ee75c