### PR TITLE
Blur page when fields are locked

### DIFF
--- a/app.js
+++ b/app.js
@@ -645,6 +645,8 @@
       const email= $('#authEmail');
       if (btn){ btn.disabled=false; btn.dataset.loading='false'; btn.textContent='Sign in'; }
       modal.classList.remove('hidden');
+      const cancel = $('#authCancel');
+      if (cancel) cancel.hidden = document.body.classList.contains('locked');
       setTimeout(()=> email?.focus(), 0);
       return;
     }
@@ -783,7 +785,9 @@
       });
 
       document.getElementById('authCancel')?.addEventListener('click', () => {
-        document.getElementById('authModal')?.classList.add('hidden');
+        if (!document.body.classList.contains('locked')) {
+          document.getElementById('authModal')?.classList.add('hidden');
+        }
       });
     }
   } // end wireEvents
@@ -792,6 +796,8 @@
   let unsubscribeGroup = null;
 
   function setFieldsLocked(lock){
+    document.body.classList.toggle('locked', lock);
+    if (lock) openAuthModal(); else closeAuthModal();
     $$("input, button, select, textarea").forEach(el => {
       if (el.id === 'loginBtn') return;
       if (el.closest('#authModal')) return;

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,8 @@ h1{font-size:28px}
 h2{font-size:20px;color:var(--muted);font-weight:600}
 
 .wrap{max-width:1400px;margin:28px auto;padding:0 16px}
+body.locked .wrap{filter:blur(4px);pointer-events:none}
+body.locked #authModal{filter:none;pointer-events:auto}
 .grid{display:grid;gap:16px;grid-template-columns:1.4fr .8fr}
 @media (max-width:1200px){.wrap{max-width:98vw}.grid{grid-template-columns:1fr}}
 


### PR DESCRIPTION
## Summary
- Automatically display the auth modal whenever fields are locked and hide it once unlocked
- Suppress the auth modal's cancel action while locked to prevent dismissing the sign-in prompt

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd996cc70832fbd03862ec57ee75c