### PR TITLE
Show sign-in modal by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -840,6 +840,7 @@
         if (logoutBtn) logoutBtn.style.display = 'none';
         clearUIOnSignOut();
         setFieldsLocked(true);
+        openAuthModal();
       }
     });
   }
@@ -852,7 +853,8 @@
     if (!ok) console.warn('Firebase SDK not ready in time');
 
     renderPeople(); renderExpenses(); computeBalances(); updateSplitUI();
-    setFieldsLocked(true);
+    // Wait for auth state before locking the interface
+    setFieldsLocked(false);
     applyTheme(localStorage.getItem('spl-theme')||'dark');
     if ($('#saveStatus')) markSaved();
 


### PR DESCRIPTION
## Summary
- Show authentication modal automatically when users are signed out
- Avoid blurring the interface before auth state is known

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Splitty/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689de6e0c3c0832f8ee5c2ec3db39256