### PR TITLE
Add persistent currency symbol to amount inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,13 @@
           <div class="col-8"><label>Description</label><input id="desc" placeholder="e.g. Groceries" autocomplete="off" /></div>
 
           <!-- Negative amounts allowed -->
-          <div class="col-4"><label>Amount</label><input type="number" id="amount" step="0.01" /></div>
+          <div class="col-4">
+            <label>Amount</label>
+            <div class="currency-input">
+              <span class="currency-symbol">$</span>
+              <input type="number" id="amount" step="0.01" />
+            </div>
+          </div>
 
           <div class="col-4"><label>Payer</label><select id="payer"></select></div>
           <div class="col-4"><label>Split</label>
@@ -184,7 +190,13 @@
       <div class="row">
         <div class="col-6"><label>From (payer)</label><select id="settleFrom"></select></div>
         <div class="col-6"><label>To (recipient)</label><select id="settleTo"></select></div>
-        <div class="col-6"><label>Amount</label><input type="number" id="settleAmount" step="0.01" placeholder="0.00"/></div>
+        <div class="col-6">
+          <label>Amount</label>
+          <div class="currency-input">
+            <span class="currency-symbol">$</span>
+            <input type="number" id="settleAmount" step="0.01" placeholder="0.00"/>
+          </div>
+        </div>
         <div class="col-6"><label>Date</label><input type="date" id="settleDate"/></div>
         <div class="col-12 small muted">Meaning: <em>From pays To</em>. Can be partial. If backwards, use <strong>Swap</strong>.</div>
         <div class="col-12 small" id="settlePreview"></div>
@@ -205,7 +217,13 @@
         <div class="row">
           <div class="col-6"><label>Date</label><input type="date" id="editDate"></div>
           <div class="col-6"><label>Description</label><input id="editDesc" placeholder="e.g. Groceries"/></div>
-          <div class="col-4"><label>Amount</label><input type="number" id="editAmount" step="0.01"></div>
+          <div class="col-4">
+            <label>Amount</label>
+            <div class="currency-input">
+              <span class="currency-symbol">$</span>
+              <input type="number" id="editAmount" step="0.01">
+            </div>
+          </div>
           <div class="col-4"><label>Payer</label><select id="editPayer"></select></div>
           <div class="col-4"><label>Split</label>
             <select id="editSplitType">
@@ -223,7 +241,13 @@
         <div class="row">
           <div class="col-6"><label>From (payer)</label><select id="editFrom"></select></div>
           <div class="col-6"><label>To (recipient)</label><select id="editTo"></select></div>
-          <div class="col-6"><label>Amount</label><input type="number" id="editSettleAmount" step="0.01"></div>
+          <div class="col-6">
+            <label>Amount</label>
+            <div class="currency-input">
+              <span class="currency-symbol">$</span>
+              <input type="number" id="editSettleAmount" step="0.01">
+            </div>
+          </div>
           <div class="col-6"><label>Date</label><input type="date" id="editSettleDate"></div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,16 @@ input,select{
 
 input[type="number"]{appearance:textfield}
 
+.currency-input{position:relative}
+.currency-input .currency-symbol{
+  position:absolute;
+  top:50%;left:12px;
+  transform:translateY(-50%);
+  pointer-events:none;
+  color:var(--muted);
+}
+.currency-input input{padding-left:28px}
+
 button{
   background:#1f2a44;color:var(--text);border:none;border-radius:12px;
   padding:12px 16px;min-height:44px;cursor:pointer;transition:.15s;box-shadow:var(--shadow)


### PR DESCRIPTION
## Summary
- Prefix amount fields with a persistent dollar sign
- Style new currency input wrapper for consistent layout

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfa2c28ec832f9ff945cafa231aaa