### PR TITLE
Revamp interface styling and improve mobile layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -877,7 +877,7 @@
     renderPeople(); renderExpenses(); computeBalances(); updateSplitUI();
     // Wait for auth state before locking the interface
     setFieldsLocked(false);
-    applyTheme(localStorage.getItem('spl-theme')||'dark');
+    applyTheme(localStorage.getItem('spl-theme')||'light');
     if ($('#saveStatus')) markSaved();
 
     wireEvents();

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/styles.css
+++ b/styles.css
@@ -1,25 +1,32 @@
-/* ===== Core tokens (dark) ===== */
+/* ===== Core tokens (light) ===== */
 :root{
-  --bg1:#0b0f17; --bg2:#0f172a; --card:#121826;
-  --muted:#8ea1b3; --text:#e8eef6; --accent:#6ee7b7; --danger:#fda4af;
-  --shadow:0 10px 30px rgba(0,0,0,.35);
-  --hairline:rgba(255,255,255,.06);
-  --input:#0b1220; --ghost:#111827;
-  color-scheme:dark;
+  --bg1:#f9fafb; --bg2:#f1f5f9; --card:#ffffff;
+  --text:#1f2937; --muted:#6b7280;
+  --accent:#3b82f6; --accent-600:#2563eb; --accent-100:#dbeafe;
+  --danger:#ef4444;
+  --shadow:0 4px 12px rgba(0,0,0,.08);
+  --hairline:#e5e7eb; --border:#e5e7eb;
+  --input:#ffffff; --ghost:#f3f4f6; --ghost-hover:#e5e7eb; --ghost-border:#e5e7eb;
+  --chip-bg:#f3f4f6; --chip-text:#1f2937; --chip-border:#d1d5db; --chip-active:#e0f2fe;
+  --thead-bg:#f9fafb; --row-alt:#f8fafc;
+  --shadow-1:0 4px 12px rgba(0,0,0,.04);
+  --cal-icon:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%230b0f17"><path d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1V3a1 1 0 0 1 1-1ZM5 7v12h14V7H5Zm3 3h2v2H8v-2Zm0 4h2v2H8v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Z"/></svg>');
+  color-scheme:light;
 }
 
-/* ===== Light theme base tokens (overrides) ===== */
-[data-theme="light"]{
-  --bg1:#f7f8fb; --bg2:#eef2f7; --card:#ffffff;
-  --text:#111827; --muted:#667085;
-  --hairline:rgba(0,0,0,.08); --input:#ffffff; --ghost:#f1f5f9;
-  --border:#e5e7eb;
-  --accent:#22c55e; --accent-600:#16a34a; --accent-100:#d1fadf;
-  --chip-bg:#f2f4f7; --chip-text:#1d2939; --chip-border:#d0d5dd; --chip-active:#e8faef;
-  --thead-bg:#f8fafc; --row-alt:#fafafa;
-  --ghost-hover:#f3f4f6; --ghost-border:#e5e7eb;
-  --shadow-1:0 10px 25px rgba(16,24,40,.06), 0 2px 8px rgba(16,24,40,.04);
-  color-scheme:light;
+/* ===== Dark theme overrides ===== */
+[data-theme="dark"]{
+  --bg1:#0b0f17; --bg2:#0f172a; --card:#121826;
+  --text:#e8eef6; --muted:#8ea1b3;
+  --accent:#3b82f6; --accent-600:#1d4ed8; --accent-100:#1e3a8a;
+  --hairline:rgba(255,255,255,.06); --border:rgba(255,255,255,.06);
+  --input:#0b1220; --ghost:#111827; --ghost-hover:#1f2937; --ghost-border:#1f2937;
+  --chip-bg:#1f2937; --chip-text:#d1d5db; --chip-border:#374151; --chip-active:#1e3a8a;
+  --thead-bg:#1e293b; --row-alt:rgba(255,255,255,0.03);
+  --shadow:0 10px 30px rgba(0,0,0,.35);
+  --shadow-1:0 10px 25px rgba(16,24,40,.4), 0 2px 8px rgba(16,24,40,.2);
+  --cal-icon:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23ffffff"><path d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1V3a1 1 0 0 1 1-1ZM5 7v12h14V7H5Zm3 3h2v2H8v-2Zm0 4h2v2H8v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Z"/></svg>');
+  color-scheme:dark;
 }
 
 /* --- iOS text-zoom + control font size --- */
@@ -31,25 +38,21 @@ input,select,textarea,button { font-size:16px; line-height:1.3; }
 html,body{height:100%}
 body{
   margin:0;
-  background:linear-gradient(160deg,var(--bg1),var(--bg2) 60%,var(--bg1));
+  background:var(--bg1);
   color:var(--text);
   font:15px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial;
-}
-
-/* Light page background polish */
-[data-theme="light"] body{
-  background: radial-gradient(1400px 500px at 50% -200px, #ffffff 10%, var(--bg1) 60%);
+  overflow-x:hidden;
 }
 
 h1,h2{margin:0 0 .6rem 0}
 h1{font-size:28px}
 h2{font-size:20px;color:var(--muted);font-weight:600}
 
-.wrap{max-width:1400px;margin:28px auto;padding:0 16px}
+.wrap{max-width:1000px;margin:28px auto;padding:0 16px}
 body.locked .wrap{filter:blur(4px);pointer-events:none}
 body.locked #authModal{filter:none;pointer-events:auto}
 .grid{display:grid;gap:16px;grid-template-columns:1.4fr .8fr}
-@media (max-width:1200px){.wrap{max-width:98vw}.grid{grid-template-columns:1fr}}
+@media (max-width:1200px){.wrap{max-width:100%;padding:0 12px}.grid{grid-template-columns:1fr}}
 
 .card{
   background:var(--card);
@@ -58,17 +61,13 @@ body.locked #authModal{filter:none;pointer-events:auto}
   box-shadow:var(--shadow);
   border:1px solid var(--hairline);
 }
-[data-theme="light"] .card{ border:1px solid var(--border); box-shadow:var(--shadow-1); }
 
 label{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);margin:10px 0 6px}
 input,select{
   width:100%;padding:12px 12px;min-height:44px;
   border-radius:12px;border:1px solid var(--hairline);background:var(--input);color:var(--text)
 }
-[data-theme="light"] input,[data-theme="light"] select{ border:1px solid var(--border); background:#fff; color:var(--text); }
-[data-theme="light"] input:focus,[data-theme="light"] select:focus{
-  outline:none;border-color:#94a3b8; box-shadow:0 0 0 3px rgba(34,197,94,.15);
-}
+
 
 input[type="number"]{appearance:textfield}
 
@@ -83,41 +82,28 @@ input[type="number"]{appearance:textfield}
 .currency-input input{padding-left:28px}
 
 button{
-  background:#1f2a44;color:var(--text);border:none;border-radius:12px;
-  padding:12px 16px;min-height:44px;cursor:pointer;transition:.15s;box-shadow:var(--shadow)
+  background:var(--ghost);color:var(--text);border:1px solid var(--ghost-border);border-radius:12px;
+  padding:12px 16px;min-height:44px;cursor:pointer;transition:.15s;box-shadow:var(--shadow-1);
 }
-[data-theme="light"] button{
-  background:var(--ghost);
-  color:var(--text);
-  border:1px solid var(--ghost-border);
-  box-shadow:var(--shadow-1);
-}
-button:hover{transform:translateY(-1px);filter:brightness(1.1)}
-.btn-accent{background:linear-gradient(135deg,#34d399,#22c55e);color:#fff}
-[data-theme="light"] .btn-accent{background:linear-gradient(180deg,var(--accent) 0%,var(--accent-600) 100%);border:1px solid rgba(0,0,0,.04)}
-[data-theme="light"] .btn-accent:hover{filter:brightness(0.98)}
-.btn-ghost{background:var(--ghost)}
-[data-theme="light"] .btn-ghost{background:transparent;color:var(--text);border:1px solid transparent}
-[data-theme="light"] .btn-ghost:hover{background:var(--ghost-hover);border-color:var(--ghost-border)}
-[data-theme="light"] .btn-ghost.icon{border-radius:9999px;padding:6px 8px}
+button:hover{transform:translateY(-1px);filter:brightness(0.98)}
+.btn-accent{background:linear-gradient(180deg,var(--accent) 0%,var(--accent-600) 100%);color:#fff;border:1px solid rgba(0,0,0,.04)}
+.btn-ghost{background:transparent}
+.btn-ghost:hover{background:var(--ghost-hover)}
+.btn-ghost.icon{border-radius:9999px;padding:6px 8px}
 
 .row{display:grid;grid-template-columns:repeat(12,1fr);gap:10px}
 .col-6{grid-column:span 6}.col-4{grid-column:span 4}.col-3{grid-column:span 3}.col-8{grid-column:span 8}.col-12{grid-column:span 12}
 
 table{width:100%;border-collapse:collapse;margin-top:10px;font-size:14px}
 th,td{padding:10px;border-bottom:1px solid var(--hairline);vertical-align:top}
-th{text-align:left;color:#a6b8ca;font-weight:600}
-[data-theme="light"] th{color:#334155}
-.pill{display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:999px;background:#0e1726;color:var(--muted);font-size:12px}
+th{text-align:left;color:var(--muted);font-weight:600}
+.pill{display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:999px;background:var(--ghost);color:var(--muted);font-size:12px}
 .muted{color:var(--muted)}
 .right{display:flex;gap:8px;justify-content:flex-end;align-items:center;flex-wrap:wrap}
 .flex{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-.tag{font-size:12px;padding:2px 8px;border-radius:999px;background:#0e1726;color:#9fb3c8;cursor:pointer}
-.tag.all{font-weight:800;color:#ffffff;border:none}
-[data-theme="light"] .tag{background:var(--chip-bg);color:var(--chip-text);border:1px solid var(--chip-border)}
-[data-theme="light"] .tag:hover{background:#eef2f6}
-[data-theme="light"] .tag.all{font-weight:600}
-[data-theme="light"] .tag.active{background:var(--chip-active);border-color:#86efac}
+.tag{font-size:12px;padding:2px 8px;border-radius:999px;background:var(--chip-bg);color:var(--chip-text);border:1px solid var(--chip-border);cursor:pointer}
+.tag.all{font-weight:600}
+.tag.active{background:var(--chip-active);border-color:var(--accent-600);color:var(--text)}
 .chip-divider{width:1px;height:18px;background:var(--hairline);display:inline-block;align-self:center;margin:0 4px}
 
 .pos{color:var(--accent)}.neg{color:var(--danger)}
@@ -125,8 +111,6 @@ th{text-align:left;color:#a6b8ca;font-weight:600}
 .mono{font-family:ui-monospace,Menlo,Consolas,"Courier New",monospace;white-space:nowrap}
 
 /* calendar icon (always visible) */
-:root{--cal-icon:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23ffffff"><path d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1V3a1 1 0 0 1 1-1ZM5 7v12h14V7H5Zm3 3h2v2H8v-2Zm0 4h2v2H8v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Z"/></svg>');}
-[data-theme="light"]{--cal-icon:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%230b0f17"><path d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 1 1 2 0v1h1a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1V3a1 1 0 0 1 1-1ZM5 7v12h14V7H5Zm3 3h2v2H8v-2Zm0 4h2v2H8v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Z"/></svg>');}
 input[type="date"]{background-image:none;padding-right:40px}
 input[type="date"]::-webkit-calendar-picker-indicator{
   background-image:var(--cal-icon);
@@ -145,10 +129,6 @@ input[type="date"]::-webkit-calendar-picker-indicator{
 #balances .bal-row .label{color:var(--muted)}
 #balances .bal-sep{height:1px;background:var(--hairline);border-radius:1px}
 #balances .bal-amt{font-weight:600}
-[data-theme="light"] .balcard{background:#fff;border:1px solid var(--border);box-shadow:var(--shadow-1)}
-[data-theme="light"] .bal-amt{color:var(--text)}
-[data-theme="light"] .bal-amt.pos{color:#16a34a}
-[data-theme="light"] .bal-amt.neg{color:#dc2626}
 
 /* wider columns */
 #expensesTable .split-amts{white-space:nowrap}
@@ -160,7 +140,6 @@ input[type="date"]::-webkit-calendar-picker-indicator{
 .modal.hidden{display:none}
 .modal-card{background:var(--card);border-radius:16px;box-shadow:var(--shadow);border:1px solid var(--hairline);padding:16px;max-width:640px;width:100%}
 .modal-card h3{margin:0 0 8px 0}
-[data-theme="light"] .modal-card{background:#fff;border:1px solid var(--border);box-shadow:var(--shadow-1)}
 .warn{color:#fbbf24}
 .icon{width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;border-radius:10px}
 .icon-edit{color:#f59e0b}
@@ -175,17 +154,12 @@ input[type="date"]::-webkit-calendar-picker-indicator{
 .save-pill{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--muted);
   padding:4px 8px;border-radius:999px;background:transparent;border:1px solid var(--hairline);margin-left:8px}
 .save-pill .dot{width:6px;height:6px;border-radius:50%;background:currentColor;display:inline-block}
-[data-theme="light"] .save-pill{background:#fff;border:1px solid var(--border);color:#475467}
 
 /* table polish for light */
-[data-theme="light"] #expensesTable thead th{background:var(--thead-bg);border-bottom:1px solid var(--border);color:#334155}
-[data-theme="light"] #expensesTable tbody tr{border-bottom:1px solid var(--border)}
-[data-theme="light"] #expensesTable tbody tr:nth-child(odd){background:var(--row-alt)}
-[data-theme="light"] #expensesTable td,[data-theme="light"] #expensesTable th{color:var(--text)}
 
-/* zebra rows + hover (dark) */
-#expensesTable tbody tr:nth-child(even){ background: rgba(255,255,255,0.02); }
-#expensesTable tbody tr:hover{ background: rgba(255,255,255,0.05); }
+/* zebra rows + hover */
+#expensesTable tbody tr:nth-child(even){ background: rgba(0,0,0,0.02); }
+#expensesTable tbody tr:hover{ background: rgba(0,0,0,0.05); }
 
 /* sticky head */
 .scroll-expenses thead th{position:sticky;top:0;z-index:1;backdrop-filter:blur(4px)}
@@ -194,6 +168,8 @@ input[type="date"]::-webkit-calendar-picker-indicator{
 @media (max-width:900px){
   .wrap{margin:16px auto}
   .grid{grid-template-columns:1fr}
+  .grid .card:first-child{order:2}
+  .grid .card:nth-child(2){order:1}
   .right{justify-content:flex-start}
   .card{padding:14px}
   h1{font-size:24px}


### PR DESCRIPTION
## Summary
- Adopt a light, minimalist color palette with complementary accents and simplified component styles
- Set light theme as default and allow dark mode overrides; theme toggle persists selection
- Improve mobile layout by reordering cards and preventing horizontal overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dff1bbbd0832f85d58026e5ad90ea