### PR TITLE
Simplify UI and improve mobile layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,7 @@
   function setStatus(text, mode) {
     const el = $('#saveStatus');
     if (!el) return;
-    el.style.color = (mode === 'ok') ? 'var(--accent)' : '#fbbf24';
+    el.style.color = (mode === 'ok') ? 'var(--positive)' : '#fbbf24';
     const spans = el.querySelectorAll('span');
     if (spans.length) spans[spans.length - 1].textContent = text;
   }
@@ -565,44 +565,6 @@
     wrap.dataset.txns = JSON.stringify(txns);
   }
 
-  // ---------- export / import / reset ----------
-  function exportJSON(){
-    const blob=new Blob([JSON.stringify(state,null,2)],{type:'application/json'});
-    const a=document.createElement('a');
-    a.href=URL.createObjectURL(blob);
-    a.download='splitty-data.json';
-    a.click();
-  }
-  function importJSON(file){
-    const reader=new FileReader();
-    reader.onload=e=>{
-      try{
-        const data=JSON.parse(e.target.result);
-        if(!Array.isArray(data.people)||!Array.isArray(data.expenses)) throw 0;
-        state.people=data.people; state.expenses=data.expenses;
-        save(); renderPeople(); renderExpenses(); computeBalances();
-      }catch{ alert('Invalid file.'); }
-    };
-    reader.readAsText(file);
-  }
-
-  // generic confirm for reset; keeps original function name for wiring
-  async function openResetConfirm(){
-    const yes = await confirmAction({
-      title: 'Reset all data?',
-      message: 'This will remove all people and transactions. This cannot be undone.',
-      okText: 'Yes, reset',
-      cancelText: 'Cancel'
-    });
-    if (yes) doReset();
-  }
-  function doReset(){
-    state.people=[]; state.expenses=[];
-    localStorage.removeItem(LAST_KEY);
-    save(); renderPeople(); renderExpenses(); computeBalances(); updateSplitUI();
-    setStatus('Synced from cloud','ok');
-  }
-
   // ---------- split UI hints ----------
   function updateSplitUI(){
     const type = $('#splitType')?.value;
@@ -715,12 +677,6 @@
     // People / expense
     $('#addPerson')?.addEventListener('click', addPerson);
     $('#addExpense')?.addEventListener('click', addExpense);
-    $('#exportBtn')?.addEventListener('click', exportJSON);
-    $('#importBtn')?.addEventListener('click', ()=> $('#importFile')?.click());
-    $('#importFile')?.addEventListener('change', e=>{ if(e.target.files[0]) importJSON(e.target.files[0]); });
-
-    // Reset confirm (now uses generic confirm)
-    $('#resetAll')?.addEventListener('click', openResetConfirm);
 
     // Split UI
     $('#splitType')?.addEventListener('change', updateSplitUI);

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 
     <div class="grid">
       <!-- LEFT: People + Add Expense + Expenses -->
-      <div class="card">
+      <div class="card main-card">
         <h2>
           People
           <span id="saveStatus"
@@ -52,7 +52,6 @@
           <div class="col-3"><label>&nbsp;</label><button class="btn-accent" id="addPerson">Add person</button></div>
           <div class="col-3 right"><label>&nbsp;</label>
             <button class="btn-ghost" id="themeToggle" title="Switch theme">☀️ Light</button>
-            <button class="btn-ghost" id="resetAll" title="Clear all data">Reset</button>
             <button class="btn-ghost" id="loginBtn" type="button">Sign in</button>
             <button class="btn-ghost" id="logoutBtn" type="button" style="display:none">Sign out</button>
           </div>
@@ -99,14 +98,12 @@
           <div class="col-12 right">
             <button id="addExpense" class="btn-accent">Add expense</button>
             <button id="settleBtn">Settle up</button>
-            <span style="flex:1"></span>
-            <button id="exportBtn">Export JSON</button>
-            <input type="file" id="importFile" accept="application/json" style="display:none">
-            <button id="importBtn">Import</button>
           </div>
         </div>
 
-        <div class="scroll-expenses">
+        <details id="expensesSection">
+          <summary>Expenses</summary>
+          <div class="scroll-expenses">
           <table id="expensesTable">
             <colgroup>
               <col><col><col><col>
@@ -129,18 +126,21 @@
             </thead>
             <tbody></tbody>
           </table>
-        </div>
+          </div>
+        </details>
       </div>
 
       <!-- RIGHT: Balances + Settle Up -->
-      <div class="card">
+      <div class="card balances-card">
         <h2>Balances</h2>
         <div id="balances"></div>
         <p class="muted small">Paid/Owes include expenses + settlements. Net = Paid &minus; Owes.</p>
         <hr />
-        <h2>Suggested settle-up</h2>
-        <div id="settlements"></div>
-        <p class="muted small">Click <strong>Use</strong> to prefill the dialog, or <strong>Pay</strong> to post the exact settlement now.</p>
+        <details id="settleSection">
+          <summary>Suggested settle-up</summary>
+          <div id="settlements"></div>
+          <p class="muted small">Click <strong>Use</strong> to prefill the dialog, or <strong>Pay</strong> to post the exact settlement now.</p>
+        </details>
       </div>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,13 @@
 /* ===== Core tokens (dark) ===== */
-:root{
-  --bg1:#0b0f17; --bg2:#0f172a; --card:#121826;
-  --muted:#8ea1b3; --text:#e8eef6; --accent:#6ee7b7; --danger:#fda4af;
-  --shadow:0 10px 30px rgba(0,0,0,.35);
-  --hairline:rgba(255,255,255,.06);
-  --input:#0b1220; --ghost:#111827;
-  color-scheme:dark;
-}
+  :root{
+    --bg1:#0b0f17; --bg2:#0f172a; --card:#121826;
+    --muted:#8ea1b3; --text:#e8eef6; --accent:#3b82f6; --danger:#fda4af;
+    --positive:#16a34a;
+    --shadow:0 10px 30px rgba(0,0,0,.35);
+    --hairline:rgba(255,255,255,.06);
+    --input:#0b1220; --ghost:#111827;
+    color-scheme:dark;
+  }
 
 /* ===== Light theme base tokens (overrides) ===== */
 [data-theme="light"]{
@@ -14,7 +15,7 @@
   --text:#111827; --muted:#667085;
   --hairline:rgba(0,0,0,.08); --input:#ffffff; --ghost:#f1f5f9;
   --border:#e5e7eb;
-  --accent:#22c55e; --accent-600:#16a34a; --accent-100:#d1fadf;
+    --accent:#3b82f6; --accent-600:#2563eb; --accent-100:#dbeafe; --positive:#16a34a;
   --chip-bg:#f2f4f7; --chip-text:#1d2939; --chip-border:#d0d5dd; --chip-active:#e8faef;
   --thead-bg:#f8fafc; --row-alt:#fafafa;
   --ghost-hover:#f3f4f6; --ghost-border:#e5e7eb;
@@ -31,9 +32,10 @@ input,select,textarea,button { font-size:16px; line-height:1.3; }
 html,body{height:100%}
 body{
   margin:0;
-  background:linear-gradient(160deg,var(--bg1),var(--bg2) 60%,var(--bg1));
+  background:var(--bg1);
   color:var(--text);
   font:15px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial;
+  overflow-x:hidden;
 }
 
 /* Light page background polish */
@@ -55,10 +57,10 @@ body.locked #authModal{filter:none;pointer-events:auto}
   background:var(--card);
   border-radius:18px;
   padding:18px;
-  box-shadow:var(--shadow);
+  box-shadow:none;
   border:1px solid var(--hairline);
 }
-[data-theme="light"] .card{ border:1px solid var(--border); box-shadow:var(--shadow-1); }
+[data-theme="light"] .card{ border:1px solid var(--border); box-shadow:none; }
 
 label{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);margin:10px 0 6px}
 input,select{
@@ -84,16 +86,16 @@ input[type="number"]{appearance:textfield}
 
 button{
   background:#1f2a44;color:var(--text);border:none;border-radius:12px;
-  padding:12px 16px;min-height:44px;cursor:pointer;transition:.15s;box-shadow:var(--shadow)
+  padding:12px 16px;min-height:44px;cursor:pointer;transition:.15s;box-shadow:none
 }
 [data-theme="light"] button{
   background:var(--ghost);
   color:var(--text);
   border:1px solid var(--ghost-border);
-  box-shadow:var(--shadow-1);
+  box-shadow:none;
 }
 button:hover{transform:translateY(-1px);filter:brightness(1.1)}
-.btn-accent{background:linear-gradient(135deg,#34d399,#22c55e);color:#fff}
+.btn-accent{background:linear-gradient(135deg,#3b82f6,#2563eb);color:#fff}
 [data-theme="light"] .btn-accent{background:linear-gradient(180deg,var(--accent) 0%,var(--accent-600) 100%);border:1px solid rgba(0,0,0,.04)}
 [data-theme="light"] .btn-accent:hover{filter:brightness(0.98)}
 .btn-ghost{background:var(--ghost)}
@@ -120,7 +122,7 @@ th{text-align:left;color:#a6b8ca;font-weight:600}
 [data-theme="light"] .tag.active{background:var(--chip-active);border-color:#86efac}
 .chip-divider{width:1px;height:18px;background:var(--hairline);display:inline-block;align-self:center;margin:0 4px}
 
-.pos{color:var(--accent)}.neg{color:var(--danger)}
+.pos{color:var(--positive)}.neg{color:var(--danger)}
 .small{font-size:12px}
 .mono{font-family:ui-monospace,Menlo,Consolas,"Courier New",monospace;white-space:nowrap}
 
@@ -147,8 +149,16 @@ input[type="date"]::-webkit-calendar-picker-indicator{
 #balances .bal-amt{font-weight:600}
 [data-theme="light"] .balcard{background:#fff;border:1px solid var(--border);box-shadow:var(--shadow-1)}
 [data-theme="light"] .bal-amt{color:var(--text)}
-[data-theme="light"] .bal-amt.pos{color:#16a34a}
+[data-theme="light"] .bal-amt.pos{color:var(--positive)}
 [data-theme="light"] .bal-amt.neg{color:#dc2626}
+
+details summary{
+  cursor:pointer;
+  font-size:20px;
+  color:var(--muted);
+  font-weight:600;
+  margin:10px 0;
+}
 
 /* wider columns */
 #expensesTable .split-amts{white-space:nowrap}
@@ -192,8 +202,9 @@ input[type="date"]::-webkit-calendar-picker-indicator{
 
 /* Mobile tweaks */
 @media (max-width:900px){
-  .wrap{margin:16px auto}
-  .grid{grid-template-columns:1fr}
+  .wrap{margin:16px auto;max-width:100%;padding:0 12px}
+  .grid{display:flex;flex-direction:column}
+  .balances-card{order:-1}
   .right{justify-content:flex-start}
   .card{padding:14px}
   h1{font-size:24px}


### PR DESCRIPTION
## Summary
- Highlight positive balances and sync status in green
- Strip export/import/reset controls for a leaner toolbar
- Hide expenses and settle-up details behind collapsible sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dff1bbbd0832f85d58026e5ad90ea