### PR TITLE
Swap user icon for Users button and improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,23 +38,17 @@
     <div class="grid">
       <!-- LEFT: People + Add Expense + Expenses -->
       <div class="card main-card">
-        <h2>
-          People
-          <span id="saveStatus"
-                class="save-pill">
-            <span class="dot"></span>
-            <span>Saved • just now</span>
-          </span>
-        </h2>
-
         <div class="row">
           <div class="col-12 right">
-            <button class="btn-ghost" id="userBtn" title="Manage users">👤</button>
+            <span id="saveStatus" class="save-pill">
+              <span class="dot"></span>
+              <span>Saved • just now</span>
+            </span>
+            <button class="btn-ghost" id="userBtn" type="button">Users</button>
             <button class="btn-ghost" id="loginBtn" type="button">Sign in</button>
             <button class="btn-ghost" id="logoutBtn" type="button" style="display:none">Sign out</button>
           </div>
         </div>
-        <div id="peopleList" class="small muted" style="margin-top:8px"></div>
         <hr />
 
         <h2>Add expense</h2>

--- a/styles.css
+++ b/styles.css
@@ -209,7 +209,8 @@ details summary{
   .card{padding:14px}
   h1{font-size:24px}
   h2{font-size:18px}
-  .row{grid-template-columns:1fr}
+  .row{grid-template-columns:repeat(12,1fr)}
+  .row > [class^="col-"]{grid-column:span 12}
   #expensesTable th.split-amts, #expensesTable td.split-amts{width:auto}
   #expensesTable th.split-rule, #expensesTable td.split-rule{width:auto}
 }


### PR DESCRIPTION
## Summary
- Replace person icon with a text "Users" button matching other ghost buttons
- Remove People heading and people list to streamline the UI
- Stack expense entry fields on mobile for better spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e0bcd34d8832faf57ef32a814daa1