### PR TITLE
Add settlement tracking and balances

### DIFF
--- a/balances.js
+++ b/balances.js
@@ -1,0 +1,26 @@
+(function(global){
+  'use strict';
+  function calculateAggregates(people = [], expenses = [], settlements = []){
+    const paid    = Object.fromEntries(people.map(p => [p, 0]));
+    const owed    = Object.fromEntries(people.map(p => [p, 0]));
+    const settled = Object.fromEntries(people.map(p => [p, 0]));
+    expenses.forEach(e => {
+      paid[e.payer] = (paid[e.payer] || 0) + (e.amount || 0);
+      if (e.shares){
+        Object.entries(e.shares).forEach(([p, share]) => {
+          owed[p] = (owed[p] || 0) + share;
+        });
+      }
+    });
+    settlements.forEach(s => {
+      settled[s.fromUserId] = (settled[s.fromUserId] || 0) + s.amount;
+      settled[s.toUserId]   = (settled[s.toUserId]   || 0) - s.amount;
+    });
+    const net = Object.fromEntries(
+      people.map(p => [p, (paid[p] || 0) - (owed[p] || 0) + (settled[p] || 0)])
+    );
+    return { paid, owed, settled, net };
+  }
+  if (typeof module !== 'undefined' && module.exports) module.exports = { calculateAggregates };
+  global.calculateAggregates = calculateAggregates;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
 
 <link rel="stylesheet" href="/styles.css">
 
+<script defer src="/balances.js"></script>
 <!-- Load app.js ONCE -->
 <script defer src="/app.js"></script>
   
@@ -126,7 +127,7 @@
       <div class="card balances-card">
         <h2>Balances</h2>
         <div id="balances"></div>
-        <p class="muted small">Paid/Owes include expenses + settlements. Net = Paid &minus; Owes.</p>
+        <p class="muted small">Paid/Owes include expenses. Settled reflects repayments. Net = Paid &minus; Owes + Settled.</p>
         <hr />
         <details id="settleSection">
           <summary>Suggested settle-up</summary>

--- a/test/balances.test.js
+++ b/test/balances.test.js
@@ -1,0 +1,33 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { calculateAggregates } = require('../balances.js');
+
+test('payer settles full amount → Net goes to 0', () => {
+  const people = ['A','B'];
+  const expenses = [{ amount:20, payer:'A', participants:['A','B'], shares:{A:10, B:10} }];
+  const settlements = [{ fromUserId:'B', toUserId:'A', amount:10, date:'2024-01-01' }];
+  const { net, settled } = calculateAggregates(people, expenses, settlements);
+  assert.equal(net.A, 0);
+  assert.equal(net.B, 0);
+  assert.equal(settled.B, 10);
+  assert.equal(settled.A, -10);
+});
+
+test('partial settlement reduces net', () => {
+  const people = ['A','B'];
+  const expenses = [{ amount:20, payer:'A', participants:['A','B'], shares:{A:10, B:10} }];
+  const settlements = [{ fromUserId:'B', toUserId:'A', amount:5, date:'2024-01-01' }];
+  const { net } = calculateAggregates(people, expenses, settlements);
+  assert.equal(net.A, 5);
+  assert.equal(net.B, -5);
+});
+
+test('receiver gets money → Settled negative and net closer to zero', () => {
+  const people = ['A','B'];
+  const expenses = [{ amount:20, payer:'A', participants:['A','B'], shares:{A:10, B:10} }];
+  const settlements = [{ fromUserId:'B', toUserId:'A', amount:4, date:'2024-01-01' }];
+  const { settled, net } = calculateAggregates(people, expenses, settlements);
+  assert.equal(settled.A, -4);
+  assert.equal(net.A, 6);
+  assert.equal(net.B, -6);
+});


### PR DESCRIPTION
## Summary
- Track direct repayments in a new `settlements` list and incorporate them into balance calculations
- Show Paid, Owes, Settled and Net in balances panel with colored currency
- Add tests for full and partial settlements and for recipients receiving money

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689e116730c4832fbf262fe77cfed145