### PR TITLE
Track settled in/out separately in balances

### DIFF
--- a/app.js
+++ b/app.js
@@ -520,13 +520,14 @@
 
   // ---------- render: balances + suggestions ----------
   function computeBalances(){
-    const {net, paid, owed, settled} = calculateAggregates(state.people, state.expenses, state.settlements);
+    const {net, paid, owed, settledOut, settledIn} = calculateAggregates(state.people, state.expenses, state.settlements);
     const wrap = $('#balances'); if(!wrap) return;
     wrap.innerHTML='';
     state.people.forEach(p=>{
       const paidVal = paid[p]||0;
       const owesVal = owed[p]||0;
-      const setVal  = settled[p]||0;
+      const outVal  = settledOut[p]||0;
+      const inVal   = settledIn[p]||0;
       const n = net[p]||0;
       const card = document.createElement('div');
       card.className='balcard';
@@ -536,7 +537,9 @@
         <div class="bal-sep"></div>
         <div class="bal-row"><span class="label">Owes</span><span class="bal-amt mono">$${currency(owesVal)}</span></div>
         <div class="bal-sep"></div>
-        <div class="bal-row"><span class="label">Settled</span><span class="bal-amt mono ${setVal>=0?'pos':'neg'}">${setVal>=0?'+':'-'}$${currency(Math.abs(setVal))}</span></div>
+        <div class="bal-row"><span class="label" title="Repayments you made">Settled (out)</span><span class="bal-amt mono neg">-$${currency(outVal)}</span></div>
+        <div class="bal-sep"></div>
+        <div class="bal-row"><span class="label" title="Repayments you received">Settled (in)</span><span class="bal-amt mono pos">+$${currency(inVal)}</span></div>
         <div class="bal-sep"></div>
         <div class="bal-row"><span class="label">Net</span><span class="bal-amt mono ${n>=0?'pos':'neg'}">${n>=0?'+':'-'}$${currency(Math.abs(n))}</span></div>
       `;

--- a/balances.js
+++ b/balances.js
@@ -1,9 +1,10 @@
 (function(global){
   'use strict';
   function calculateAggregates(people = [], expenses = [], settlements = []){
-    const paid    = Object.fromEntries(people.map(p => [p, 0]));
-    const owed    = Object.fromEntries(people.map(p => [p, 0]));
-    const settled = Object.fromEntries(people.map(p => [p, 0]));
+    const paid       = Object.fromEntries(people.map(p => [p, 0]));
+    const owed       = Object.fromEntries(people.map(p => [p, 0]));
+    const settledOut = Object.fromEntries(people.map(p => [p, 0]));
+    const settledIn  = Object.fromEntries(people.map(p => [p, 0]));
     expenses.forEach(e => {
       paid[e.payer] = (paid[e.payer] || 0) + (e.amount || 0);
       if (e.shares){
@@ -13,13 +14,13 @@
       }
     });
     settlements.forEach(s => {
-      settled[s.fromUserId] = (settled[s.fromUserId] || 0) + s.amount;
-      settled[s.toUserId]   = (settled[s.toUserId]   || 0) - s.amount;
+      settledOut[s.fromUserId] = (settledOut[s.fromUserId] || 0) + s.amount;
+      settledIn[s.toUserId]   = (settledIn[s.toUserId]   || 0) + s.amount;
     });
     const net = Object.fromEntries(
-      people.map(p => [p, (paid[p] || 0) - (owed[p] || 0) + (settled[p] || 0)])
+      people.map(p => [p, (paid[p] || 0) - (owed[p] || 0) + ((settledOut[p] || 0) - (settledIn[p] || 0))])
     );
-    return { paid, owed, settled, net };
+    return { paid, owed, settledOut, settledIn, net };
   }
   if (typeof module !== 'undefined' && module.exports) module.exports = { calculateAggregates };
   global.calculateAggregates = calculateAggregates;

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
       <div class="card balances-card">
         <h2>Balances</h2>
         <div id="balances"></div>
-        <p class="muted small">Paid/Owes include expenses. Settled reflects repayments. Net = Paid &minus; Owes + Settled.</p>
+        <p class="muted small">Paid/Owes include expenses. Settled (out/in) reflect repayments. Net = Paid &minus; Owes + (Settled out &minus; Settled in).</p>
         <hr />
         <details id="settleSection">
           <summary>Suggested settle-up</summary>

--- a/test/balances.test.js
+++ b/test/balances.test.js
@@ -6,28 +6,30 @@ test('payer settles full amount → Net goes to 0', () => {
   const people = ['A','B'];
   const expenses = [{ amount:20, payer:'A', participants:['A','B'], shares:{A:10, B:10} }];
   const settlements = [{ fromUserId:'B', toUserId:'A', amount:10, date:'2024-01-01' }];
-  const { net, settled } = calculateAggregates(people, expenses, settlements);
+  const { net, settledOut, settledIn } = calculateAggregates(people, expenses, settlements);
   assert.equal(net.A, 0);
   assert.equal(net.B, 0);
-  assert.equal(settled.B, 10);
-  assert.equal(settled.A, -10);
+  assert.equal(settledOut.B, 10);
+  assert.equal(settledIn.A, 10);
 });
 
 test('partial settlement reduces net', () => {
   const people = ['A','B'];
   const expenses = [{ amount:20, payer:'A', participants:['A','B'], shares:{A:10, B:10} }];
   const settlements = [{ fromUserId:'B', toUserId:'A', amount:5, date:'2024-01-01' }];
-  const { net } = calculateAggregates(people, expenses, settlements);
+  const { net, settledOut, settledIn } = calculateAggregates(people, expenses, settlements);
   assert.equal(net.A, 5);
   assert.equal(net.B, -5);
+  assert.equal(settledOut.B, 5);
+  assert.equal(settledIn.A, 5);
 });
 
-test('receiver gets money → Settled negative and net closer to zero', () => {
+test('receiver gets money → Settled in positive and net closer to zero', () => {
   const people = ['A','B'];
   const expenses = [{ amount:20, payer:'A', participants:['A','B'], shares:{A:10, B:10} }];
   const settlements = [{ fromUserId:'B', toUserId:'A', amount:4, date:'2024-01-01' }];
-  const { settled, net } = calculateAggregates(people, expenses, settlements);
-  assert.equal(settled.A, -4);
+  const { settledIn, net } = calculateAggregates(people, expenses, settlements);
+  assert.equal(settledIn.A, 4);
   assert.equal(net.A, 6);
   assert.equal(net.B, -6);
 });


### PR DESCRIPTION
## Summary
- Split settlement totals into separate settled out and settled in values
- Show distinct settled rows in balances UI and compute net accordingly
- Update balances copy and tests for new settlement tracking

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689e834f9b4c832f885a7a8afab112cb