### PR TITLE
Add interactive expenses table with filters and month grouping

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@
   const GROUP_ID = 'couple';
   let state = safeJSON(localStorage.getItem('spl-lite')) ?? { people: [], expenses: [], settlements: [] };
   if (!state.settlements) state.settlements = [];
+  window.state = state;
 
   // ---------- save status pill ----------
   let _saveTimer = null;
@@ -463,8 +464,8 @@
     if (yes) deleteExpense(id);
   }
 
-  // ---------- render: expenses (newest first) ----------
-  function renderExpenses(){
+  // ---------- render: expenses (legacy table, unused) ----------
+  function renderExpensesLegacy(){
     function formatRule(e){
       const map={
         settlement:'Settlement',
@@ -541,6 +542,10 @@
         </td>`;
       tbody.appendChild(tr);
     });
+  }
+
+  function renderExpenses(){
+    window.renderExpenses?.();
   }
 
   // ---------- render: balances + suggestions ----------
@@ -854,6 +859,7 @@
   function clearUIOnSignOut(){
     // Clear in-memory + local cache (do NOT touch Firestore)
     state = { people: [], expenses: [], settlements: [] };
+    window.state = state;
     localStorage.removeItem('spl-lite');
     renderPeople(); renderExpenses(); computeBalances(); updateSplitUI(); renderUserList();
     // Reset some form fields for a fresh look

--- a/app.js
+++ b/app.js
@@ -790,7 +790,7 @@
         }
       });
       expCont.addEventListener('deleteExpense', (e) => {
-        deleteExpense(e.detail.id);
+        confirmDelete(e.detail.id);
       });
     }
 

--- a/app.js
+++ b/app.js
@@ -773,6 +773,22 @@
       const btnEdit=e.target.closest?.('.btn-edit'); if(btnEdit){ openEditModal(btnEdit.dataset.id); }
     });
 
+    // Inline table events from expenses.js
+    const expCont = document.getElementById('expensesContainer');
+    if (expCont) {
+      expCont.addEventListener('updateExpense', (e) => {
+        const { id, patch } = e.detail || {};
+        const idx = state.expenses.findIndex(x => x.id === id);
+        if (idx >= 0) {
+          state.expenses[idx] = { ...state.expenses[idx], ...patch };
+          save(); renderExpenses(); computeBalances();
+        }
+      });
+      expCont.addEventListener('deleteExpense', (e) => {
+        deleteExpense(e.detail.id);
+      });
+    }
+
     // Edit modal
     $('#editCancel')?.addEventListener('click', closeEditModal);
     $('#editSave')?.addEventListener('click', saveEdit);

--- a/expenses.css
+++ b/expenses.css
@@ -1,0 +1,28 @@
+.table { width: 100%; border-collapse: separate; border-spacing: 0; }
+.table th, .table td { padding: 10px 12px; vertical-align: middle; }
+.table thead th { position: sticky; top: 0; backdrop-filter: blur(4px); z-index:2; }
+.table tr:nth-child(even) { background: rgba(255,255,255,0.03); }
+.table tbody tr:hover { background: rgba(255,255,255,0.06); }
+.table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.table .date { width:100px; }
+.table .people { width:140px; }
+.table .amount { width:110px; }
+.table .splitRule { width:80px; }
+.table .perPerson { width:160px; }
+.monthHeader { position: sticky; top:40px; padding:6px 12px; font-weight:600; background: rgba(255,255,255,0.04); border-top:1px solid rgba(255,255,255,0.08); border-bottom:1px solid rgba(255,255,255,0.08); z-index:1; }
+.monthHeader th { text-align:left; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.small { opacity: .7; font-size: .85em; }
+.expenses-filters { display:flex; gap:8px; margin-bottom:8px; flex-wrap:wrap; }
+.expenses-filters input, .expenses-filters select { padding:6px; }
+.details { background: rgba(255,255,255,0.02); }
+.details .actions { margin-top:8px; display:flex; gap:8px; }
+.details button { padding:4px 8px; }
+@media (max-width:640px) {
+  .table .people { display:none; }
+  .table .desc.truncate { white-space:normal; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; }
+  .table td.amount, .table td.perPerson { display:block; width:100%; }
+  .table tr { display:block; }
+  .table td { display:block; width:100%; }
+  .monthHeader { top:88px; }
+}

--- a/expenses.js
+++ b/expenses.js
@@ -1,0 +1,244 @@
+const currency = new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD' });
+
+const state = {
+  expenses: [],
+  filters: { q: '', payer: 'All', from: '', to: '' },
+  container: null,
+  tbody: null,
+  expanded: new Set()
+};
+
+const filterInputs = {};
+
+function renderExpenses(container, expenses) {
+  state.container = container;
+  state.expenses = expenses.slice();
+  container.innerHTML = '';
+
+  const filtersBar = document.createElement('div');
+  filtersBar.className = 'expenses-filters';
+  filtersBar.innerHTML = `
+    <input type="search" placeholder="Search" aria-label="Search description" class="filter-q" />
+    <select class="filter-payer" aria-label="Filter by payer"><option value="All">All</option></select>
+    <input type="date" class="filter-from" aria-label="From date" />
+    <input type="date" class="filter-to" aria-label="To date" />
+  `;
+  container.appendChild(filtersBar);
+
+  filterInputs.q = filtersBar.querySelector('.filter-q');
+  filterInputs.payer = filtersBar.querySelector('.filter-payer');
+  filterInputs.from = filtersBar.querySelector('.filter-from');
+  filterInputs.to = filtersBar.querySelector('.filter-to');
+
+  // populate payers
+  const payers = Array.from(new Set(expenses.map(e => e.payer))).sort();
+  payers.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p;
+    opt.textContent = p;
+    filterInputs.payer.appendChild(opt);
+  });
+
+  const table = document.createElement('table');
+  table.className = 'table expenses-table';
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th class="date">Date</th>
+        <th class="desc">Description</th>
+        <th class="people">People</th>
+        <th class="amount num">Amount</th>
+        <th class="splitRule">Split rule</th>
+        <th class="perPerson num">Per-person</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  `;
+  container.appendChild(table);
+  state.tbody = table.querySelector('tbody');
+
+  const debounced = debounce(applyFilters, 250);
+  filterInputs.q.addEventListener('input', debounced);
+  filterInputs.payer.addEventListener('change', debounced);
+  filterInputs.from.addEventListener('change', debounced);
+  filterInputs.to.addEventListener('change', debounced);
+
+  render();
+}
+
+function setFilters(f) {
+  Object.assign(state.filters, f);
+  if (filterInputs.q) filterInputs.q.value = state.filters.q || '';
+  if (filterInputs.payer) filterInputs.payer.value = state.filters.payer || 'All';
+  if (filterInputs.from) filterInputs.from.value = state.filters.from || '';
+  if (filterInputs.to) filterInputs.to.value = state.filters.to || '';
+  render();
+}
+
+function applyFilters() {
+  state.filters.q = filterInputs.q.value;
+  state.filters.payer = filterInputs.payer.value;
+  state.filters.from = filterInputs.from.value;
+  state.filters.to = filterInputs.to.value;
+  render();
+}
+
+function render() {
+  const tbody = state.tbody;
+  tbody.innerHTML = '';
+
+  const filtered = state.expenses.filter(e => {
+    if (state.filters.q && !e.description.toLowerCase().includes(state.filters.q.toLowerCase())) return false;
+    if (state.filters.payer !== 'All' && e.payer !== state.filters.payer) return false;
+    if (state.filters.from && e.date < state.filters.from) return false;
+    if (state.filters.to && e.date > state.filters.to) return false;
+    return true;
+  }).sort((a,b) => b.date.localeCompare(a.date));
+
+  let currentMonth = '';
+  filtered.forEach(exp => {
+    const month = formatMonth(exp.date);
+    if (month !== currentMonth) {
+      currentMonth = month;
+      const mtr = document.createElement('tr');
+      mtr.className = 'monthHeader';
+      const mth = document.createElement('th');
+      mth.colSpan = 6;
+      mth.textContent = month;
+      mtr.appendChild(mth);
+      tbody.appendChild(mtr);
+    }
+
+    const tr = document.createElement('tr');
+    tr.className = 'expense-row';
+    tr.tabIndex = 0;
+    tr.dataset.id = exp.id;
+    tr.innerHTML = `
+      <td class="date">${formatDate(exp.date)}</td>
+      <td class="desc truncate" title="${escapeHtml(exp.description)}">${escapeHtml(exp.description)}</td>
+      <td class="people">${escapeHtml(exp.participants.map(p=>p.name).join(', '))}</td>
+      <td class="amount num">${currency.format(exp.amount)}</td>
+      <td class="splitRule">${splitIcon(exp.splitRule)}</td>
+      <td class="perPerson num">${exp.participants.map(p => `${escapeHtml(p.name)} ${currency.format(p.share)}`).join(' &middot; ')}</td>
+    `;
+    tr.addEventListener('click', () => toggleRow(exp.id));
+    tr.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleRow(exp.id); }
+    });
+    tbody.appendChild(tr);
+    if (state.expanded.has(exp.id)) {
+      tbody.appendChild(renderDetailsRow(exp));
+    }
+  });
+}
+
+function renderDetailsRow(exp) {
+  const tr = document.createElement('tr');
+  tr.className = 'details-row';
+  const td = document.createElement('td');
+  td.colSpan = 6;
+  td.className = 'details';
+  const people = exp.participants.map(p=>p.name).join(', ');
+  const notes = exp.notes ? `<div class="small">${escapeHtml(exp.notes)}</div>` : '';
+  const creator = exp.createdBy ? `<div class="small">Added by ${escapeHtml(exp.createdBy)}</div>` : '';
+  const receipt = exp.receiptUrl ? `<div><a href="${exp.receiptUrl}" target="_blank" rel="noopener">Receipt</a></div>` : '';
+  td.innerHTML = `<div class="small">People: ${escapeHtml(people)}</div>${notes}${creator}${receipt}<div class="actions"><button class="btn-edit">Edit</button><button class="btn-delete">Delete</button></div>`;
+  tr.appendChild(td);
+
+  td.querySelector('.btn-edit').addEventListener('click', e => {
+    e.stopPropagation();
+    startEdit(exp.id);
+  });
+  td.querySelector('.btn-delete').addEventListener('click', e => {
+    e.stopPropagation();
+    state.container.dispatchEvent(new CustomEvent('deleteExpense', { detail: { id: exp.id } }));
+  });
+  return tr;
+}
+
+function startEdit(id) {
+  const tr = state.tbody.querySelector(`tr.expense-row[data-id="${id}"]`);
+  if (!tr) return;
+  const descCell = tr.querySelector('.desc');
+  const amountCell = tr.querySelector('.amount');
+  const origDesc = descCell.textContent;
+  const origAmt = amountCell.textContent;
+
+  const descInput = document.createElement('input');
+  descInput.type = 'text';
+  descInput.value = origDesc;
+  descCell.innerHTML = '';
+  descCell.appendChild(descInput);
+  descInput.focus();
+
+  const amtInput = document.createElement('input');
+  amtInput.type = 'number';
+  amtInput.step = '0.01';
+  amtInput.value = parseFloat(origAmt.replace(/[^0-9.-]/g,'')) || 0;
+  amountCell.innerHTML = '';
+  amountCell.appendChild(amtInput);
+
+  function finish(save) {
+    if (save) {
+      const patch = { description: descInput.value, amount: parseFloat(amtInput.value) };
+      descCell.textContent = patch.description;
+      descCell.title = patch.description;
+      amountCell.textContent = currency.format(patch.amount);
+      state.container.dispatchEvent(new CustomEvent('updateExpense', { detail: { id, patch } }));
+    } else {
+      descCell.textContent = origDesc;
+      descCell.title = origDesc;
+      amountCell.textContent = origAmt;
+    }
+  }
+
+  function onKey(e) {
+    if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+    else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+  }
+
+  descInput.addEventListener('keydown', onKey);
+  amtInput.addEventListener('keydown', onKey);
+  descInput.addEventListener('blur', () => finish(true));
+  amtInput.addEventListener('blur', () => finish(true));
+}
+
+function toggleRow(id) {
+  if (state.expanded.has(id)) state.expanded.delete(id); else state.expanded.add(id);
+  render();
+}
+
+function formatMonth(dateStr) {
+  const d = new Date(dateStr);
+  return d.toLocaleString('en-AU', { month: 'long', year: 'numeric' });
+}
+
+function formatDate(dateStr) {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-AU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function splitIcon(rule) {
+  const map = {
+    equal: { emoji: '⚖️', label: 'Equal split' },
+    custom: { emoji: '🧩', label: 'Custom split' },
+    percent: { emoji: '📊', label: 'Percent split' }
+  };
+  const m = map[rule] || map.equal;
+  return `<span role="img" aria-label="${m.label}" title="${m.label}">${m.emoji}</span>`;
+}
+
+function escapeHtml(str = '') {
+  return str.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function debounce(fn, delay) {
+  let t;
+  return function(...args) {
+    clearTimeout(t);
+    t = setTimeout(() => fn.apply(this, args), delay);
+  };
+}
+
+window.renderExpenses = renderExpenses;
+window.setFilters = setFilters;

--- a/index.html
+++ b/index.html
@@ -26,10 +26,12 @@
 </script>
 
 <link rel="stylesheet" href="/styles.css">
+<link rel="stylesheet" href="/expenses.css">
 
 <script defer src="/balances.js"></script>
 <!-- Load app.js ONCE -->
 <script defer src="/app.js"></script>
+<script defer src="/expenses.js"></script>
   
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -98,29 +98,7 @@
 
         <details id="expensesSection">
           <summary>Expenses</summary>
-          <div class="scroll-expenses">
-          <table id="expensesTable">
-            <colgroup>
-              <col><col><col>
-              <col style="width:10%">
-              <col class="split-rule">
-              <col class="split-amts">
-              <col style="width:76px">
-            </colgroup>
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Description</th>
-                <th>People</th>
-                <th class="right">Amount</th>
-                <th class="split-rule">Split rule</th>
-                <th class="split-amts">Split amounts</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-          </div>
+          <div class="scroll-expenses" id="expensesContainer"></div>
         </details>
       </div>
 


### PR DESCRIPTION
## Summary
- build dynamic expenses table with search, payer, and date filters
- group expenses by month with sticky headers and currency formatting
- support row expansion with inline editing and accessible split rule icons

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a15aeeeb08832fa9ce52d22a112653